### PR TITLE
Fix json deserialization

### DIFF
--- a/src/model/message.rs
+++ b/src/model/message.rs
@@ -1,47 +1,51 @@
-use serde::{Serialize, Deserialize};
 use super::MessagePart;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CompactMessage {
-    pub id: String,
-    #[serde(default, rename = "labelIds")]
-    pub label_ids: Vec<String>,
-    #[serde(rename = "threadId")]
-    pub thread_id: String,
+	pub id: String,
+	#[serde(default, rename = "labelIds")]
+	pub label_ids: Vec<String>,
+	#[serde(rename = "threadId")]
+	pub thread_id: String,
 }
 
 ///An email message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Message {
-    ///The ID of the last history record that modified this message.
-    #[serde(default, rename = "historyId")]
-    pub history_id: String,
-    ///The immutable ID of the message.
-    pub id: String,
-    ///The internal message creation timestamp (epoch ms), which determines ordering in the inbox. For normal SMTP-received email, this represents the time the message was originally accepted by Google, which is more reliable than the `Date` header. However, for API-migrated mail, it can be configured by client to be based on the `Date` header.
-    #[serde(rename = "internalDate")]
-    pub internal_date: String,
-    ///List of IDs of labels applied to this message.
-    #[serde(rename = "labelIds")]
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub label_ids: Vec<String>,
-    ///A single MIME message part.
-    pub payload: MessagePart,
-    ///The entire email message in an RFC 2822 formatted and base64url encoded string. Returned in `messages.get` and `drafts.get` responses when the `format=RAW` parameter is supplied.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub raw: Option<String>,
-    ///Estimated size in bytes of the message.
-    #[serde(rename = "sizeEstimate")]
-    pub size_estimate: i64,
-    ///A short part of the message text.
-    pub snippet: String,
-    ///The ID of the thread the message belongs to. To add a message or draft to a thread, the following criteria must be met: 1. The requested `threadId` must be specified on the `Message` or `Draft.Message` you supply with your request. 2. The `References` and `In-Reply-To` headers must be set in compliance with the [RFC 2822](https://tools.ietf.org/html/rfc2822) standard. 3. The `Subject` headers must match.
-    #[serde(rename = "threadId")]
-    pub thread_id: String,
+	///The ID of the last history record that modified this message.
+	#[serde(default, rename = "historyId")]
+	pub history_id: String,
+	///The immutable ID of the message.
+	pub id: String,
+	///The internal message creation timestamp (epoch ms), which determines ordering in the inbox. For normal SMTP-received email, this represents the time the message was originally accepted by Google, which is more reliable than the `Date` header. However, for API-migrated mail, it can be configured by client to be based on the `Date` header.
+	#[serde(rename = "internalDate")]
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub internal_date: Option<String>,
+	///List of IDs of labels applied to this message.
+	#[serde(rename = "labelIds")]
+	#[serde(default, skip_serializing_if = "Vec::is_empty")]
+	pub label_ids: Vec<String>,
+	///A single MIME message part.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub payload: Option<MessagePart>,
+	///The entire email message in an RFC 2822 formatted and base64url encoded string. Returned in `messages.get` and `drafts.get` responses when the `format=RAW` parameter is supplied.
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub raw: Option<String>,
+	///Estimated size in bytes of the message.
+	#[serde(rename = "sizeEstimate")]
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub size_estimate: Option<i64>,
+	///A short part of the message text.
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub snippet: Option<String>,
+	///The ID of the thread the message belongs to. To add a message or draft to a thread, the following criteria must be met: 1. The requested `threadId` must be specified on the `Message` or `Draft.Message` you supply with your request. 2. The `References` and `In-Reply-To` headers must be set in compliance with the [RFC 2822](https://tools.ietf.org/html/rfc2822) standard. 3. The `Subject` headers must match.
+	#[serde(rename = "threadId")]
+	pub thread_id: String,
 }
 
 impl std::fmt::Display for Message {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        write!(f, "{}", serde_json::to_string(self).unwrap())
-    }
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+		write!(f, "{}", serde_json::to_string(self).unwrap())
+	}
 }

--- a/src/model/message.rs
+++ b/src/model/message.rs
@@ -1,51 +1,51 @@
+use serde::{Serialize, Deserialize};
 use super::MessagePart;
-use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CompactMessage {
-	pub id: String,
-	#[serde(default, rename = "labelIds")]
-	pub label_ids: Vec<String>,
-	#[serde(rename = "threadId")]
-	pub thread_id: String,
+    pub id: String,
+    #[serde(default, rename = "labelIds")]
+    pub label_ids: Vec<String>,
+    #[serde(rename = "threadId")]
+    pub thread_id: String,
 }
 
 ///An email message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Message {
-	///The ID of the last history record that modified this message.
-	#[serde(default, rename = "historyId")]
-	pub history_id: String,
-	///The immutable ID of the message.
-	pub id: String,
-	///The internal message creation timestamp (epoch ms), which determines ordering in the inbox. For normal SMTP-received email, this represents the time the message was originally accepted by Google, which is more reliable than the `Date` header. However, for API-migrated mail, it can be configured by client to be based on the `Date` header.
-	#[serde(rename = "internalDate")]
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub internal_date: Option<String>,
-	///List of IDs of labels applied to this message.
-	#[serde(rename = "labelIds")]
-	#[serde(default, skip_serializing_if = "Vec::is_empty")]
-	pub label_ids: Vec<String>,
-	///A single MIME message part.
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub payload: Option<MessagePart>,
-	///The entire email message in an RFC 2822 formatted and base64url encoded string. Returned in `messages.get` and `drafts.get` responses when the `format=RAW` parameter is supplied.
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub raw: Option<String>,
-	///Estimated size in bytes of the message.
-	#[serde(rename = "sizeEstimate")]
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub size_estimate: Option<i64>,
-	///A short part of the message text.
-	#[serde(skip_serializing_if = "Option::is_none")]
-	pub snippet: Option<String>,
-	///The ID of the thread the message belongs to. To add a message or draft to a thread, the following criteria must be met: 1. The requested `threadId` must be specified on the `Message` or `Draft.Message` you supply with your request. 2. The `References` and `In-Reply-To` headers must be set in compliance with the [RFC 2822](https://tools.ietf.org/html/rfc2822) standard. 3. The `Subject` headers must match.
-	#[serde(rename = "threadId")]
-	pub thread_id: String,
+    ///The ID of the last history record that modified this message.
+    #[serde(default, rename = "historyId")]
+    pub history_id: String,
+    ///The immutable ID of the message.
+    pub id: String,
+    ///The internal message creation timestamp (epoch ms), which determines ordering in the inbox. For normal SMTP-received email, this represents the time the message was originally accepted by Google, which is more reliable than the `Date` header. However, for API-migrated mail, it can be configured by client to be based on the `Date` header.
+    #[serde(rename = "internalDate")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub internal_date: Option<String>,
+    ///List of IDs of labels applied to this message.
+    #[serde(rename = "labelIds")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub label_ids: Vec<String>,
+    ///A single MIME message part.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload: Option<MessagePart>,
+    ///The entire email message in an RFC 2822 formatted and base64url encoded string. Returned in `messages.get` and `drafts.get` responses when the `format=RAW` parameter is supplied.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub raw: Option<String>,
+    ///Estimated size in bytes of the message.
+    #[serde(rename = "sizeEstimate")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size_estimate: Option<i64>,
+    ///A short part of the message text.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub snippet: Option<String>,
+    ///The ID of the thread the message belongs to. To add a message or draft to a thread, the following criteria must be met: 1. The requested `threadId` must be specified on the `Message` or `Draft.Message` you supply with your request. 2. The `References` and `In-Reply-To` headers must be set in compliance with the [RFC 2822](https://tools.ietf.org/html/rfc2822) standard. 3. The `Subject` headers must match.
+    #[serde(rename = "threadId")]
+    pub thread_id: String,
 }
 
 impl std::fmt::Display for Message {
-	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-		write!(f, "{}", serde_json::to_string(self).unwrap())
-	}
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "{}", serde_json::to_string(self).unwrap())
+    }
 }


### PR DESCRIPTION
This pull request includes changes to the `Message` struct in the `src/model/message.rs` file to fix a issue as of writing this pull request. The issue is that the gmail api made it so the cant get the changed field's from the users.messages.list method anymore, you can only get them from the users.messages.get method.

Changes to `Message` struct:

* Made `internal_date` an `Option<String>` and added `#[serde(default, skip_serializing_if = "Option::is_none")]` to handle default values and skip serialization when the field is `None`.
* Made `payload` an `Option<MessagePart>` and added `#[serde(default, skip_serializing_if = "Option::is_none")]` to handle default values and skip serialization when the field is `None`.
* Made `size_estimate` an `Option<i64>` and added `#[serde(default, skip_serializing_if = "Option::is_none")]` to handle default values and skip serialization when the field is `None`.
* Made `snippet` an `Option<String>` and added `#[serde(skip_serializing_if = "Option::is_none")]` to skip serialization when the field is `None`.